### PR TITLE
fix(bybit): resolve AttributeError in mechanical trading

### DIFF
--- a/rich/service.py
+++ b/rich/service.py
@@ -2586,7 +2586,9 @@ def save_portfolio_snapshot(user, balances=None):
     )
 
 
-def run_bybit_mechanical_trading(symbol="BTCUSDT", paper_mode=True):
+def run_bybit_mechanical_trading(symbol="BTCUSDT", paper_mode=None):
+    if paper_mode is None:
+        paper_mode = getattr(settings, "BYBIT_PAPER_MODE", True)
     trader = BybitMechanicalTrader(symbol=symbol, paper_mode=paper_mode)
     trader.run()
 
@@ -2649,63 +2651,6 @@ class BybitMechanicalTrader:
 
         except Exception as e:
             logging.exception(f"Error in mechanical trading cycle: {e}")
-
-    def _generate_signal(self, df):
-        close = df["close"]
-        high = df["high"]
-        low = df["low"]
-        volume = df["volume"]
-
-        rsi_series = calc_rsi(close, period=14)
-        macd_line, signal_line, hist = calc_macd(close)
-        ema20 = calc_ema(close, span=20)
-        ema50 = calc_ema(close, span=50)
-        vma20 = calc_volume_ma(volume, period=20)
-        atr14 = calc_atr(high, low, close, period=14)
-        adx = self._calculate_adx(high, low, close)
-        bb_upper, bb_mid, bb_lower = calc_bb(
-            close, period=self.params.bbands_period, num_std=self.params.bbands_std
-        )
-        atr_avg_series = atr14.rolling(window=self.params.atr_avg_period).mean()
-        atr_current = float(atr14.iloc[-1])
-        atr_avg = (
-            float(atr_avg_series.iloc[-1]) if len(atr_avg_series) > 0 else atr_current
-        )
-        atr_ratio = atr_current / atr_avg if atr_avg > 0 else 1.0
-
-        last = df.iloc[-1]
-        close_price = float(last["close"])
-        bb_u = float(bb_upper.iloc[-1])
-        bb_l = float(bb_lower.iloc[-1])
-        bb_m = float(bb_mid.iloc[-1])
-        bb_range = bb_u - bb_l
-        bb_position = ((close_price - bb_l) / bb_range * 100) if bb_range > 0 else 50.0
-        vol_ma = float(vma20.iloc[-1])
-        volume_ratio = float(last["volume"]) / vol_ma if vol_ma > 0 else 1.0
-
-        return {
-            "close": close_price,
-            "rsi": float(rsi_series.iloc[-1]),
-            "macd": float(macd_line.iloc[-1]),
-            "macd_signal": float(signal_line.iloc[-1]),
-            "macd_hist": float(hist.iloc[-1]),
-            "macd_hist_prev": float(hist.iloc[-2])
-            if len(hist) > 1
-            else float(hist.iloc[-1]),
-            "ema20": float(ema20.iloc[-1]),
-            "ema50": float(ema50.iloc[-1]),
-            "volume": float(last["volume"]),
-            "volume_ma20": vol_ma,
-            "volume_ratio": volume_ratio,
-            "atr": atr_current,
-            "atr_avg": atr_avg,
-            "atr_ratio": atr_ratio,
-            "adx": float(adx.iloc[-1]) if adx is not None else 25.0,
-            "bb_upper": bb_u,
-            "bb_mid": bb_m,
-            "bb_lower": bb_l,
-            "bb_position": bb_position,
-        }
 
     def _calculate_adx(self, high, low, close, period=14):
         try:
@@ -2934,6 +2879,16 @@ class BybitMechanicalTrader:
             score_short=cond["met_short"],
             indicators=indicators,
         )
+
+    def _should_enter(self, signal):
+        if not signal.action:
+            return False
+
+        open_trades = BybitMechanicalTrade.objects.filter(
+            symbol=self.symbol, is_open=True, side=signal.action
+        )
+
+        return not open_trades.exists()
 
     def _execute_entry(self, signal):
         leverage = self._calculate_leverage(signal.indicators)


### PR DESCRIPTION
## Summary

Fix AttributeError: 'BybitMechanicalTrader' object has no attribute '_should_enter' that was occurring during mechanical trading cycles.

## Changes

### Bug Fixes
- **Removed duplicate _generate_signal method**: There were two versions - one taking df as parameter and one fetching data internally. The parameterized version was removed to maintain consistency.

- **Added missing _should_enter method**: This method prevents duplicate positions by checking if an open trade already exists for the same symbol and side.

- **Updated run_bybit_mechanical_trading function**: Changed paper_mode=True hardcoded default to paper_mode=None, which then reads from Django settings (BYBIT_PAPER_MODE) with fallback to True. This allows configuration-based switching between paper and live trading.

## Testing
- Error no longer occurs in mechanical trading cycle
- _should_enter properly prevents duplicate position entries
- Settings-based paper mode configuration works correctly

## Files Changed
- rich/service.py (-45 lines net)

---
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)