### PR TITLE
fix(llm): add clear YAML indentation hints to prevent parse errors

### DIFF
--- a/rich/service.py
+++ b/rich/service.py
@@ -1035,7 +1035,15 @@ recommendations:
 Rules:
 1. Strictly follow the YAML structure above
 2. scratchpad and reasoning MUST use multiline string format with | operator and consistent indentation
-3. Keep total length of scratchpad + reasoning < 2000 chars
+3. CRITICAL: After the | operator, EVERY line of content MUST start with exactly 2 spaces indentation
+4. Example of CORRECT format:
+   scratchpad: |
+     First line with 2 spaces indent
+     Second line with 2 spaces indent
+5. Example of INCORRECT format (will cause parse error):
+   scratchpad: |
+   First line without indent (WRONG!)
+6. Keep total length of scratchpad + reasoning < 2000 chars
 4. Each line should be a complete, meaningful statement
 5. Use simple, clear Korean language
 6. No repetition between sections


### PR DESCRIPTION
## 문제

LLM이 YAML multiline string (>|) 사용 시 들여쓰기를 생략해서 파싱 에러 발생:



**LLM이 생성한 잘못된 YAML:**


**올바른 YAML:**


## 해결

프롬프트에 명확한 들여쓰기 규칙과 예시 추가:



## 변경사항

- : 프롬프트에 들여쓰기 규칙 강화

## 테스트

- LLM이 이제 명확히 들여쓰기 규칙을 이해할 것임

---
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>