### PR TITLE
feat: auto_trading LLM 추론을 Ollama deepseek-v4-pro로 변경

### DIFF
--- a/core/llm.py
+++ b/core/llm.py
@@ -13,6 +13,7 @@ from langchain.schema import SystemMessage
 from langchain_anthropic import ChatAnthropic
 from langchain_deepseek import ChatDeepSeek
 from langchain_google_genai import ChatGoogleGenerativeAI
+from ollama import Client as OllamaClient
 
 # Initialize the LLM
 chat_anthropic = ChatAnthropic(
@@ -58,6 +59,38 @@ chat_gemini_models = [
 
 llm_primary = chat_deepseek.with_fallbacks(chat_gemini_models)
 llm_fallback = chat_gemini_models[1]
+
+ollama_client = OllamaClient(
+    host=os.getenv("OLLAMA_HOST", "https://ollama.com"),
+    headers={"Authorization": "Bearer " + (os.getenv("OLLAMA_API_KEY") or "")},
+)
+
+
+def invoke_llm_ollama(
+    prompt, *args, model=None, template_format="f-string", **kwargs
+):
+    """Invoke Ollama chat API and optionally parse YAML into a Pydantic model."""
+    messages = [{"role": "system", "content": prompt}]
+    for arg in args:
+        if template_format == "f-string":
+            content = arg.format(**kwargs)
+        else:
+            content = arg % kwargs
+        messages.append({"role": "user", "content": content})
+
+    ollama_model = os.getenv("OLLAMA_MODEL", "deepseek-v4-pro")
+    response = ollama_client.chat(
+        model=ollama_model,
+        messages=messages,
+        stream=False,
+    )
+    raw = response.message.content
+    logging.info(f"invoke_llm_ollama model={ollama_model}: {raw[:300]}...")
+
+    if model:
+        parser = YamlOutputParser(pydantic_object=model)
+        return parser.parse(raw)
+    return raw
 
 
 def invoke_llm(

--- a/requirements.in
+++ b/requirements.in
@@ -32,6 +32,7 @@ langchain==0.3.13
 langchain-anthropic==0.3.1
 langchain-deepseek
 langchain-google-genai==2.0.7
+ollama
 google-genai==0.3.0
 
 nasdaq-data-link==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -287,6 +287,8 @@ langsmith==0.2.11
     # via
     #   langchain
     #   langchain-core
+ollama==0.6.2
+    # via -r requirements.in
 markupsafe==3.0.2
     # via
     #   jinja2

--- a/rich/service.py
+++ b/rich/service.py
@@ -42,6 +42,7 @@ from core.indicators import rsi as calc_rsi
 from core.indicators import volume_ma as calc_volume_ma
 from core.llm import invoke_gemini_search
 from core.llm import invoke_llm
+from core.llm import invoke_llm_ollama
 from core.market_time import compute_market_time
 from core.parameter_optimization import create_optimization_payload
 from core.parameter_optimization import request_optimized_parameters
@@ -1072,11 +1073,11 @@ Rules:
             recommendations=[],
         )
 
-    return invoke_llm(
+    return invoke_llm_ollama(
         prompt,
         all_data,
         model=MultiCryptoRecommendation,
-        with_fallback=with_fallback,
+        template_format="f-string",
         **kwargs,
     )
 

--- a/tests/test_llm_ollama.py
+++ b/tests/test_llm_ollama.py
@@ -1,0 +1,81 @@
+import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+from pydantic import Field
+
+from core.llm import invoke_llm_ollama
+from core.llm import ollama_client
+
+
+class _MockRecommendation(BaseModel):
+    scratchpad: str = Field(..., description="Analysis")
+    reasoning: str = Field(..., description="Reasoning")
+    recommendations: list = Field(default_factory=list, description="Recommendations")
+
+
+@pytest.fixture
+def mock_ollama_response():
+    return MagicMock(
+        message=MagicMock(
+            content="""
+scratchpad: |
+  Test analysis
+reasoning: |
+  Test reasoning
+recommendations: []
+"""
+        )
+    )
+
+
+def test_invoke_llm_ollama_parses_yaml_into_model(mock_ollama_response):
+    with patch.object(ollama_client, "chat", return_value=mock_ollama_response) as mock_chat:
+        result = invoke_llm_ollama(
+            "You are a trading advisor",
+            "Market data: {test_data}",
+            model=_MockRecommendation,
+            template_format="f-string",
+            test_data="BTC is up 5%",
+        )
+
+    assert isinstance(result, _MockRecommendation)
+    assert result.scratchpad.strip() == "Test analysis"
+    assert result.reasoning.strip() == "Test reasoning"
+    assert result.recommendations == []
+
+    call_args = mock_chat.call_args[1]
+    assert call_args["model"] == os.getenv("OLLAMA_MODEL", "deepseek-v4-pro")
+    assert call_args["stream"] is False
+    messages = call_args["messages"]
+    assert messages[0]["role"] == "system"
+    assert "trading advisor" in messages[0]["content"]
+    assert messages[1]["role"] == "user"
+    assert "BTC is up 5%" in messages[1]["content"]
+
+
+def test_invoke_llm_ollama_returns_raw_string_when_no_model(mock_ollama_response):
+    with patch.object(ollama_client, "chat", return_value=mock_ollama_response) as mock_chat:
+        result = invoke_llm_ollama(
+            "System prompt",
+            "User prompt",
+        )
+
+    assert isinstance(result, str)
+    assert "scratchpad" in result
+    mock_chat.assert_called_once()
+
+
+@pytest.mark.skipif(
+    not os.getenv("OLLAMA_API_KEY"),
+    reason="No OLLAMA_API_KEY set",
+)
+def test_invoke_llm_ollama_real_api():
+    result = invoke_llm_ollama(
+        "You are a helpful assistant. Reply with exactly one word.",
+        "Say hello.",
+    )
+    assert isinstance(result, str)
+    assert "hello" in result.lower()


### PR DESCRIPTION
## 변경 내용
- `auto_trading`의 LLM 추론 엔진을 기존 `langchain_deepseek` 기반 `invoke_llm`에서 Ollama 클라우드 API의 `deepseek-v4-pro`를 사용하는 `invoke_llm_ollama`로 교체했습니다.
- `core/llm.py`에 `ollama` Python 라이브러리(`0.6.2`)를 이용한 `OllamaClient` 및 `invoke_llm_ollama` 함수를 추가했습니다.
- `rich/service.py`의 `get_multi_recommendation`에서 `invoke_llm` 호출을 `invoke_llm_ollama` 호출로 변경했습니다.

## 환경 변수
`.env`에 이미 설정된 값을 그대로 사용합니다:
- `OLLAMA_API_KEY`
- `OLLAMA_HOST` (기본값: `https://ollama.com`)
- `OLLAMA_MODEL` (기본값: `deepseek-v4-pro`)

## 테스트
- `tests/test_llm_ollama.py`에 Ollama 호출 및 YAML 파싱을 검증하는 유닛 테스트를 추가했습니다.
- 실제 Ollama API 호출 테스트도 포함되어 있으며, `OLLAMA_API_KEY`가 있는 경우만 실행됩니다.
- 모든 테스트 통과 확인 완료.

## 의존성
- `requirements.in` 및 `requirements.txt`에 `ollama==0.6.2`를 추가했습니다.