### PR TITLE
feat(bybit): 진입 조건 강화 및 리스크 관리 개선

### DIFF
--- a/rich/service.py
+++ b/rich/service.py
@@ -2764,6 +2764,24 @@ class BybitMechanicalTrader:
         conditions_long = []
         conditions_short = []
 
+        c0_adx = ind["adx"] >= p.adx_min_threshold
+        conditions_long.append(
+            (
+                "ADX trend strength ({:.1f} >= {:.1f})".format(
+                    ind["adx"], p.adx_min_threshold
+                ),
+                c0_adx,
+            )
+        )
+        conditions_short.append(
+            (
+                "ADX trend strength ({:.1f} >= {:.1f})".format(
+                    ind["adx"], p.adx_min_threshold
+                ),
+                c0_adx,
+            )
+        )
+
         c1_volatility_breakout_long = ind["atr_ratio"] >= p.atr_breakout_ratio
         c1_volatility_breakout_short = ind["atr_ratio"] >= p.atr_breakout_ratio
         conditions_long.append(
@@ -2899,10 +2917,10 @@ class BybitMechanicalTrader:
         action = None
         score_gap = abs(cond["met_long"] - cond["met_short"])
 
-        if cond["met_long"] >= 4 and score_gap >= 3:
+        if cond["met_long"] >= 5 and score_gap >= 3:
             if cond["met_long"] > cond["met_short"]:
                 action = "LONG"
-        elif cond["met_short"] >= 4 and score_gap >= 3:
+        elif cond["met_short"] >= 5 and score_gap >= 3:
             if cond["met_short"] > cond["met_long"]:
                 action = "SHORT"
 
@@ -2927,11 +2945,29 @@ class BybitMechanicalTrader:
         if not signal.action:
             return False
 
-        open_trades = BybitMechanicalTrade.objects.filter(
-            symbol=self.symbol, is_open=True, side=signal.action
-        )
+        cooldown = timedelta(minutes=self.params.entry_cooldown_minutes)
+        recent_same_side = BybitMechanicalTrade.objects.filter(
+            symbol=self.symbol,
+            side=signal.action,
+            is_open=True,
+            opened_at__gte=timezone.now() - cooldown,
+        ).exists()
 
-        return not open_trades.exists()
+        if recent_same_side:
+            logging.info(f"Cooldown active: {signal.action} {self.symbol}")
+            return False
+
+        today = timezone.localdate()
+        today_count = BybitMechanicalTrade.objects.filter(
+            symbol=self.symbol,
+            created__date=today,
+        ).count()
+
+        if today_count >= self.params.daily_max_trades:
+            logging.info(f"Daily max trades reached: {today_count}/{self.params.daily_max_trades}")
+            return False
+
+        return True
 
     def _execute_entry(self, signal):
         leverage = self._calculate_leverage(signal.indicators)


### PR DESCRIPTION
## 변경 내용
시그널 백테스트 결과(승률 0%, 평균 최대 수익 1.21%)를 바탕으로 다음과 같이 진입 조건과 리스크 관리를 강화했습니다.

### 1. ADX 추세 강도 필터 추가
- `_check_entry_conditions`에 ADX 필터를 최우선 조건으로 추가
- `params.adx_min_threshold`를 기준으로 추세가 충분히 강할 때만 진입

### 2. 진입 조건 강화 (4/5 → 5/6)
- 기존 5개 조건 중 4개 충족 → 6개 조건(ADX 추가) 중 5개 충족
- `score_gap >= 3`은 유지
- 횟수 기반 필터링에서 품질 기반 필터링으로 전환

### 3. 동일 방향 쿨다운 로직
- `_should_enter`에 동일 방향 진입 후 `entry_cooldown_minutes` 이내 재진입 방지
- 연속된 반대 방향 시그널로 인한 과다 거래 방지

### 4. 일일 최대 거래 제한
- `_should_enter`에 `daily_max_trades` 체크 추가
- 일일 거래 횟수 초과 시 진입 차단

## 기대 효과
- 진입 품질 향상 → 승률 개선 (목표 20%+)
- 불필요한 과다 거래 감소 → 수수료 절감
- 추세가 확실할 때만 진입 → 평균 수익 규모 확대