### PR TITLE
chore(cron): auto_trading을 Zappa event에서 고정 IP cron으로 이관

### DIFF
--- a/rich_trader/settings/base.py
+++ b/rich_trader/settings/base.py
@@ -214,6 +214,9 @@ CRONJOBS = [
         ">> /tmp/bybit_mechanical.log 2>&1",
     ),
     ("30 0 * * *", "rich.service.bybit_daily_review", ">> /tmp/bybit_review.log 2>&1"),
+    # Coinone API IP 제한으로 Zappa event 대신 고정 IP cron으로 이관.
+    # 기존 Zappa event: cron(15 * * * ? *) (매 시간 15분)
+    ("15 * * * *", "rich.service.auto_trading", ">> /tmp/auto_trading.log 2>&1"),
 ]
 CRONTAB_COMMAND_PREFIX = "USE_DB_URL=1"
 CRONTAB_DJANGO_SETTINGS_MODULE = "rich_trader.settings.prod"


### PR DESCRIPTION
## 배경

Coinone API에 IP 제한이 추가되어 Zappa(Lambda) event로 실행되던 `auto_trading`이 더 이상 정상 동작하지 않습니다. Lambda는 outbound IP가 고정되지 않기 때문입니다.

## 변경 내용

- `rich_trader/settings/base.py`의 `CRONJOBS`에 `rich.service.auto_trading` 추가
  - cron 식: `15 * * * *` (매 시간 15분) — 기존 Zappa event `cron(15 * * * ? *)`과 동일한 스케줄
  - 로그: `>> /tmp/auto_trading.log 2>&1`
- 기존 Zappa event(`zappa_settings.json`)에서 `auto_trading` 항목 제거

> `zappa_settings.json`은 `.gitignore`에 등록된 로컬/배포서버 전용 파일이라 이 PR에 포함되지 않습니다. 배포 서버의 `zappa_settings.json`에서도 `rich.service.auto_trading` event를 수동으로 제거해야 합니다.

## 배포 후 수동 작업

1. 배포 서버의 `zappa_settings.json`에서 `auto_trading` event 항목 삭제
2. `zappa unschedule prod` 후 `zappa schedule prod` 로 Zappa event 갱신 (auto_trading event 제거)
3. 고정 IP 서버에서 `python manage.py crontab add` 로 CRONJOBS 등록

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)